### PR TITLE
Patch to listpolicies.sh

### DIFF
--- a/provision_vault/scripts/listpolicies.sh
+++ b/provision_vault/scripts/listpolicies.sh
@@ -2,12 +2,12 @@
 
   ##  Get global list of policies
 curl -k \
-    --request GET \
+    --request LIST \
     --header "X-Vault-Token: $VAULT_TOKEN" \
-    "$VAULT_ADDR/v1/sys/policies/acl" | jq
+    "$VAULT_ADDR/v1/sys/policies/acl" | jq '.data.keys'
 
   ##  List specific policy
 curl -k \
-    --request GET \
+    --request LIST \
     --header "X-Vault-Token: $VAULT_TOKEN" \
     "$VAULT_ADDR/v1/sys/policies/acl/admin" | jq


### PR DESCRIPTION
-curl with the method GET gives the error "unsupported operation", works fine with the method LIST. 
-Add "'.data.keys'" after jq to display only the list of policies.