### PR TITLE
Add TLS support, self-signed TLS Certs

### DIFF
--- a/PRODUCTION_INSTALLATION.md
+++ b/PRODUCTION_INSTALLATION.md
@@ -36,11 +36,11 @@ They'll then use the Vault API to initialize the Vault using `init.sh` and set u
   
   Here's the content of the /etc/profile.d/vault.sh that I have on my latest Vagrant setup: 
 
-export VAULT_ADDR=http://127.0.0.1:8200  ##  Add local Vault address to startup script
+export VAULT_ADDR=https://127.0.0.1:8200  ##  Add local Vault address to startup script
 
 Yours could be this: 
 
-export VAULT_ADDR=http://vaultlb.mycorp.com  ##  Add Vault Load Balancer address to startup script
+export VAULT_ADDR=https://vaultlb.mycorp.com  ##  Add Vault Load Balancer address to startup script
 
 
 or 

--- a/README.md
+++ b/README.md
@@ -64,15 +64,20 @@ Consul is on port 8500.
 
 ### Click the Links
 
-http://192.168.13.35:8200 (Vault)
+NOTE: You will need to tell
+your browser to trust the Certificates
+generated during the provisioning
+process. 
+
+https://192.168.13.35:8200 (Vault)
 
 http://192.168.13.35:8500 (Consul)
 
-http://192.168.13.36:8200 (Vault)
+https://192.168.13.36:8200 (Vault)
 
 http://192.168.13.36:8500 (Consul)
 
-http://192.168.13.37:8200 (Vault)
+https://192.168.13.37:8200 (Vault)
 
 http://192.168.13.37:8500 (Consul)
 
@@ -83,7 +88,7 @@ _Related Vendor Documentation Link: https://www.vaultproject.io/api/system/init.
 Start Vault.  
 Run this command on one of the Vagrant-managed VMs, or somewhere on your computer that has `curl` installed.  
 ```
-    curl -s --request PUT -d '{"secret_shares": 3,"secret_threshold": 2}' http://192.168.13.35:8200/v1/sys/init
+    curl -s --request PUT -d '{"secret_shares": 3,"secret_threshold": 2}' https://192.168.13.35:8200/v1/sys/init
 ```
 
 ### Unseal Vault  
@@ -95,20 +100,25 @@ This will unseal the Vault at `192.168.13.35:8200`.  You can use the same proces
 1. Use your unseal key to replace the value for key `abcd1430890...`, and run this on the Vagrant-managed VM.  
 
 ```
-    curl --request PUT --data '{"key":"abcd12345678..."}' http://192.168.13.35:8200/v1/sys/unseal
+    curl --request PUT --data '{"key":"abcd12345678..."}' https://192.168.13.35:8200/v1/sys/unseal
 ```
 
 2. Run that `curl` command again. But use a different value for `"key":`. Replace `efgh2541901...` with a different key than you used in the previous step, from the keys you received when running the `v1/sys/init` endpoint.  
 
 ```
-    curl --request PUT --data '{"key":"efgh910111213..."}' http://192.168.13.35:8200/v1/sys/unseal
+    curl --request PUT --data '{"key":"efgh910111213..."}' https://192.168.13.35:8200/v1/sys/unseal
 ```
 
 # Non-Vagrant
 
-Please refer to the file PRODUCTION_INSTALLATION.md in this repository.
+Please refer to the file `PRODUCTION_INSTALLATION.md` in this repository.
 
+# Certificates
 
+Vagrant generates some self-signed certificates for each
+Vault node. 
+
+Please refer to the `README.md` file in this repository, inside the `certs` folder.
 
 # Codified Vault Policies and Configuration
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,13 @@ Vagrant.configure("2") do |config|
             server.vm.provision "shell", path: "configureconsul.sh"
             server.vm.provision "shell", inline: "sudo systemctl enable consul.service"
             server.vm.provision "shell", inline: "sudo systemctl start consul"
+            server.vm.provision "shell", inline: "sudo mkdir -p /etc/vault.d/tls/"
+            server.vm.provision "shell", inline: "/vagrant/certs/generate-sslcerts.sh 192.168.13.3#{i}"
+            server.vm.provision "shell", inline: "sudo cp /vagrant/certs/basanese.com-192.168.13.3#{i}.crt /etc/vault.d/tls/vault.crt"
+            server.vm.provision "shell", inline: "sudo cp /vagrant/certs/basanese.com-192.168.13.3#{i}.key /etc/vault.d/tls/vault.key"
             server.vm.provision "shell", path: "vaultdownload.sh", args: ["1.0.0-rc1", "/usr/local/bin"]
+            server.vm.provision "shell", inline: "sudo chmod 0700 /etc/vault.d/tls/"
+            server.vm.provision "shell", inline: "sudo chmod 0600 /etc/vault.d/tls/vault.key"
             
               ##  API Provisioning
             if "#{i}" == "7"

--- a/certs/.gitignore
+++ b/certs/.gitignore
@@ -1,0 +1,6 @@
+  ##  Ignore TLS artifacts
+*.key
+*.crt
+*.conf
+*.info
+*.pem

--- a/certs/README.md
+++ b/certs/README.md
@@ -1,0 +1,16 @@
+## Vault Certificates
+
+Vagrant will create self-signed
+certificates for each of the
+Vault nodes, install them,
+and add them to the root trust store.
+
+If you want to see these certificates,
+check this folder after Vagrant
+has provisioned the Vault cluster. 
+
+The `generate-sslcerts.sh` script
+also downloads and modifies a
+a CA bundle to include the newly
+generated Vault certificates, at
+`certs/anchors`.

--- a/certs/generate-sslcerts.sh
+++ b/certs/generate-sslcerts.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# input IP address 
+IP=$1
+
+# Set the TLD domain we want to use
+BASE_DOMAIN="basanese.com"
+
+# Days for the cert to live
+DAYS=365
+
+# A blank passphrase
+PASSPHRASE=""
+
+# The file name can be anything
+FILE_NAME="/vagrant/certs/$BASE_DOMAIN-${IP}"
+
+# Remove previous keys
+echo "Removing existing certs like $FILE_NAME.*"
+chmod 770 $FILE_NAME.crt || true
+chmod 770 $FILE_NAME.info || true
+chmod 770 $FILE_NAME.key || true
+rm $FILE_NAME.*
+rm -f $FILE_NAME.crt
+rm -f $FILE_NAME.info
+rm -f $FILE_NAME.key
+
+# Generated configuration file
+CONFIG_FILE="$FILE_NAME.conf"
+
+cat > $CONFIG_FILE <<-EOF
+[req]
+default_bits = 4096
+prompt = no
+default_md = sha256
+x509_extensions = v3_req
+distinguished_name = dn
+
+[dn]
+C = US
+ST = CA
+L = SanJose
+O = Basanese
+OU = InformationSecurity
+emailAddress = devops@$BASE_DOMAIN
+CN = $BASE_DOMAIN
+
+[v3_req]
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = *.$BASE_DOMAIN
+DNS.2 = $BASE_DOMAIN
+IP = ${IP}
+EOF
+
+echo "Generating certs for $BASE_DOMAIN"
+
+# Generate our Private Key, CSR and Certificate
+# Use SHA-2 as SHA-1 is unsupported from Jan 1, 2017
+
+openssl req -new -x509 -newkey rsa:4096 \
+	-sha256 -nodes -keyout "$FILE_NAME.key" \
+	-days $DAYS -out "$FILE_NAME.crt" \
+	-passin pass:$PASSPHRASE -config "$CONFIG_FILE"
+
+# OPTIONAL - write an info to see the details of the generated crt
+openssl x509 -noout -fingerprint -text < "$FILE_NAME.crt" > "$FILE_NAME.info"
+
+# Protect the key
+chmod 400 "$FILE_NAME.key"
+
+##  Deploy the Vault Certificate
+
+cp "$FILE_NAME.key" /etc/vault.d/tls/vault.key
+cp "$FILE_NAME.crt" /etc/vault.d/tls/vault.crt
+chown vault:vault /etc/vault.d/tls/vault.key
+chown vault:vault /etc/vault.d/tls/vault.crt
+
+
+# Create a Certificate Bundle
+# Update root trust store
+# Set environment variable for CLI use
+
+  ##  Create a separate place to work with Trust Anchors
+mkdir -p /vagrant/certs/anchors/
+
+  ##  Download a CA bundle to the Trust Anchors folder, and combine Vault certs there, too. 
+curl --silent https://curl.haxx.se/ca/cacert.pem -o /vagrant/certs/anchors/cacert.pem
+cat /vagrant/certs/*.crt >> /vagrant/certs/anchors/vault_certs_bundle.crt
+
+  ##  Update OS Root Trust Store
+  ##  Add Curl's default cert bundle to the root trust store, and
+  ##  add the combined Vault certificates to it.
+cat /vagrant/certs/anchors/vault_certs_bundle.crt >> /vagrant/certs/anchors/cacert.pem
+cp /vagrant/certs/anchors/cacert.pem /etc/pki/tls/certs/ca-bundle.crt
+cp /vagrant/certs/anchors/vault_certs_bundle.crt /etc/pki/ca-trust/source/anchors/
+update-ca-trust
+
+##  In case update-ca-trust is being unreliable: 
+cp $FILE_NAME.crt /etc/pki/tls/certs/
+cd /etc/pki/tls/certs/
+ls "${BASE_DOMAIN}-${IP}.crt"
+echo "${BASE_DOMAIN}-${IP}.crt"
+sudo ln -sv "${BASE_DOMAIN}-${IP}.crt" $(openssl x509 -in "${BASE_DOMAIN}-${IP}.crt" -noout -hash).0
+
+##  Update some Environment Variables for 
+##  convenient use of Vault from the CLI.
+
+echo "export CURL_CA_BUNDLE=/vagrant/certs/anchors/cacert.pem" >> /home/vagrant/.bashrc
+echo "export CURL_CA_BUNDLE=/vagrant/certs/anchors/cacert.pem" >> ~/.bashrc
+echo "export VAULT_CACERT=/vagrant/certs/anchors/cacert.pem" >> /home/vagrant/.bashrc
+echo "export VAULT_CACERT=/vagrant/certs/anchors/cacert.pem" >> ~/.bashrc
+echo "export VAULT_CAPATH=/vagrant/certs/anchors/" >> /home/vagrant/.bashrc
+echo "export VAULT_CAPATH=/vagrant/certs/anchors/" >> ~/.bashrc
+echo "export VAULT_ADDR=https://${IP}:8200" >> /home/vagrant/.bashrc
+echo "export VAULT_ADDR=https://${IP}:8200" >> ~/.bashrc

--- a/configurevault.sh
+++ b/configurevault.sh
@@ -8,8 +8,12 @@ backend "consul" {
 }
 listener "tcp" {
   address     = "0.0.0.0:8200"
-  tls_disable = 1
+  # tls_disable = 1
+  tls_disable = 0
+  tls_cert_file = "/etc/vault.d/tls/vault.crt"
+  tls_key_file  = "/etc/vault.d/tls/vault.key"
 }
+api_addr = "https://192.168.13.35:8200"
 plugin_directory = "/etc/vault.d/plugin"
 ui=true
 EOF
@@ -18,3 +22,4 @@ echo "sed without -i"
 sed "s%VAULT_CONSUL_HTTP_TOKEN%${VAULT_CONSUL_HTTP_TOKEN}%" "/etc/vault.d/vault.hcl"
 echo "sed -i"
 sed -i "s%VAULT_CONSUL_HTTP_TOKEN%${VAULT_CONSUL_HTTP_TOKEN}%" "/etc/vault.d/vault.hcl"
+

--- a/demonstrations/database/mariadb/README.md
+++ b/demonstrations/database/mariadb/README.md
@@ -195,7 +195,7 @@ OR
         "password": "errydayimSNUFFLIN",
         "verify_connection": false
     }
-    [vagrant@instance7 mariadb]$ curl --header "X-Vault-Token: ${VAULT_TOKEN}" --request POST --data @mariadb.json     http://127.0.0.1:8200/v1/database/config/mariadb | jq
+    [vagrant@instance7 mariadb]$ curl --header "X-Vault-Token: ${VAULT_TOKEN}" --request POST --data @mariadb.json     https://127.0.0.1:8200/v1/database/config/mariadb | jq
       % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                      Dload  Upload   Total   Spent    Left  Speed
     100   505  100   162  100   343  15841  33541 --:--:-- --:--:-- --:--:-- 34300
@@ -242,7 +242,7 @@ Example Output:
     >     --header "X-Vault-Token: ${VAULT_TOKEN}" \
     >     --request POST \
     >     --data @enable_mariadb_secrets_engine.json \
-    >     http://127.0.0.1:8200/v1/sys/mounts/mariadb
+    >     https://127.0.0.1:8200/v1/sys/mounts/mariadb
     [vagrant@instance7 mariadb]$ curl -sk \
     >     --header "X-Vault-Token: ${VAULT_TOKEN}" \
     >     "${VAULT_ADDR}/v1/sys/mounts/mariadb/tune" | jq
@@ -269,11 +269,11 @@ Then:
  # Configure MariaDB Mount
 
     curl --header "X-Vault-Token: $VAULT_TOKEN" --request POST --data @mariadb.json \
-    http://127.0.0.1:8200/v1/mariadb/config/mariadb
+    https://127.0.0.1:8200/v1/mariadb/config/mariadb
 
 Example: 
 
-    [vagrant@instance7 mariadb]$ curl --header "X-Vault-Token: $VAULT_TOKEN" --request POST --data @mariadb.json     http://127.0.0.1:8200/v1/mariadb/config/mariadb
+    [vagrant@instance7 mariadb]$ curl --header "X-Vault-Token: $VAULT_TOKEN" --request POST --data @mariadb.json     https://127.0.0.1:8200/v1/mariadb/config/mariadb
     {"request_id":"93aee9eb-34e4-2220-e330-9400ccb8efd6","lease_id":"","renewable":false,"lease_duration":0,"data":null,"wrap_info":null,"warnings":null,"auth":null}
     [vagrant@instance7 mariadb]$
 
@@ -317,7 +317,7 @@ Now switch to the apps policy.
 
 Get a dynamic DB credential: 
 
-    [vagrant@instance7 mariadb]$ curl --header "X-Vault-Token: ${VAULT_TOKEN}"        --request GET        http://127.0.0.1:8200/v1/mariadb/creds/readonly | jq
+    [vagrant@instance7 mariadb]$ curl --header "X-Vault-Token: ${VAULT_TOKEN}"        --request GET        https://127.0.0.1:8200/v1/mariadb/creds/readonly | jq
       % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                      Dload  Upload   Total   Spent    Left  Speed
     100   300  100   300    0     0  13280      0 --:--:-- --:--:-- --:--:-- 13636

--- a/demonstrations/database/postgres/README.md
+++ b/demonstrations/database/postgres/README.md
@@ -232,7 +232,7 @@ Now we're going to configure this Vault **Database** Secrets Engine:
     
       * Password found in connection_url, use a templated url to enable root
       rotation and prevent read access to password information.
-    [vagrant@bdload2 postgres]$ curl --header "X-Vault-Token: ${VAULT_TOKEN}" --request POST --data @postgres.json     http://127.0.0.1:8200/v1/database/config/postgresql | jq
+    [vagrant@bdload2 postgres]$ curl --header "X-Vault-Token: ${VAULT_TOKEN}" --request POST --data @postgres.json     https://127.0.0.1:8200/v1/database/config/postgresql | jq
 
 Then make an API call to create the Vault Role, named **readonly**, for this Vault **Database** Secrets Engine:
 
@@ -257,7 +257,7 @@ Now you have a new Vault Role. You can now use that Vault Role named **readonly*
 
 Get a dynamic Database credential from the Vault Role **readonly** in the Vault **Database** Secrets Engine:
 
-    [vagrant@instance7 postgres]$ curl --header "X-Vault-Token: ${VAULT_TOKEN}"        --request GET        http://127.0.0.1:8200/v1/database/creds/readonly | jq
+    [vagrant@instance7 postgres]$ curl --header "X-Vault-Token: ${VAULT_TOKEN}"        --request GET        https://127.0.0.1:8200/v1/database/creds/readonly | jq
       % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                      Dload  Upload   Total   Spent    Left  Speed
     100   317  100   317    0     0  13534      0 --:--:-- --:--:-- --:--:-- 13782

--- a/vaultdownload.sh
+++ b/vaultdownload.sh
@@ -17,8 +17,9 @@ echo "Vault Download: https://releases.hashicorp.com/vault/${1}/vault_${1}_linux
 echo "Vault Path: ${2}"
 
 mkdir -p -v -m 0755 "${VAULT_FOLDER_PREFIX}/etc/ssl/vault/"
-mkdir -p -v -m 755 "${VAULT_FOLDER_PREFIX}/etc/vault.d"
-mkdir -p -v -m 755 "${VAULT_FOLDER_PREFIX}/etc/vault.d/plugin"
+mkdir -p -v -m 755 "${VAULT_FOLDER_PREFIX}/etc/vault.d/"
+mkdir -p -v -m 755 "${VAULT_FOLDER_PREFIX}/etc/vault.d/tls/"
+mkdir -p -v -m 755 "${VAULT_FOLDER_PREFIX}/etc/vault.d/plugin/"
 chown -R vault:vault "${VAULT_FOLDER_PREFIX}/etc/vault.d" "${VAULT_FOLDER_PREFIX}/etc/ssl/vault"
 touch "${VAULT_FOLDER_PREFIX}/etc/vault.d/vault.hcl"
 chmod -R 0644 $VAULT_FOLDER_PREFIX/etc/vault.d/*


### PR DESCRIPTION
Makes TLS usable from VMs.

This adds TLS Certificate generation
to Vault, and sets the CA
Environment Variable for Vault and
the corresponding CA Cert Environment
Variable for cURL.

These are self-signed, so they won't
totally validate outside of Vault.

But they work.

I was not able to get the OS Root Trust
Store to update properly, and some of that
code may need to be modified.

This commit also updates documentation to use HTTPS.

Updated the main docs
to show HTTPS for the Vault
servers.

People will need to temporarily
trust the self-signed certificates
generated by Vagrant for these Vault
servers.

Some of the other docs had
http://127.0.0.1:8200 as their
target for demonstrations.

Most of them refer to $VAULT_ADDR,
but I have changed the ones that
refer to a specific IP address.

Update README.md to note Trusting Self-Signed Certificates is needed.

Squashed this into the content from https://github.com/v6/super-duper-vault-train/pull/22